### PR TITLE
updates to plotting code and binsfunction

### DIFF
--- a/fullplotting.py
+++ b/fullplotting.py
@@ -5,15 +5,29 @@ def datafunction(geom, chi2lim, bestfits):
     data = pars[fitinfo.model_id[selection]]
     return pars, data
   
-def binsfunction(param, kind, binsnum, chi2lim, geometries, bestfits):
+def binsfunction(param, kind, binsnum, chi2lim, geometries, bestfits, massnum=9):
+    # note: the massnum indicates an index for aperture size, and is used in the
+    # parameters which involve multiple aperture sizes to select just one. you'll
+    # need to find out what your massnum= is if you use this.
+    
     datamin = []
     datamax = []
     for geom in geometries:
         pars, data = datafunction(geom, chi2lim, bestfits)
         if param in pars.keys():
-            datamin.append(data[param].min())
-            datamax.append(data[param].max())
+            if param == "Line-of-Sight Masses":
+                dataparam = data[param]
+                datamin.append(dataparam[massnum].min())
+                datamax.append(dataparam[massnum].max())
+            elif param == "Sphere Masses":
+                dataparam = data[param]
+                datamin.append(dataparam[massnum].min())
+                datamax.append(dataparam[massnum].max())
+            else:
+                datamin.append(data[param].min())
+                datamax.append(data[param].max())
 
+    # just some idiot-proofing because i ran into a problem with this
     for x in datamin:
         if x == 0:
             datamin.remove(x)
@@ -101,9 +115,12 @@ linnum = 50
 tempbins = binsfunction('star.temperature', 'lin', linnum, chi2limit, geometries_selection, bestfits_source)
 lumbins = binsfunction('Model Luminosity', 'log', lognum, chi2limit, geometries_selection, bestfits_source)
 radbins = binsfunction('star.radius', 'log', lognum, chi2limit, geometries_selection, bestfits_source)
-losbins = binsfunction('Line-of-Sight Masses', 'log', 10, chi2limit, geometries_selection, bestfits_source)
+losbins = binsfunction('Line-of-Sight Masses', 'log', 20, chi2limit, geometries_selection, bestfits_source, 0)
 dscbins = binsfunction('disk.mass', 'log', lognum, chi2limit, geometries_selection, bestfits_source)
-sphbins = binsfunction('Sphere Masses', 'log', lognum, chi2limit, geometries_selection, bestfits_source)
+sphbins = binsfunction('Sphere Masses', 'log', 20, chi2limit, geometries_selection, bestfits_source, 0)
+
+# index values used above and below for mass-related parameters should, i think, be the same as your
+# massnum index, which again has to do with aperture sizes
 
 for geom in geometries_selection:
     pars, data = datafunction(geom, chi2limit, bestfits_source)
@@ -118,7 +135,7 @@ for geom in geometries_selection:
         ax3.hist(data['star.radius'], bins=radbins, alpha=histalpha, label=geom)
 
     if 'Line-of-Sight Masses' in pars.keys():
-        ax4.hist(data['Line-of-Sight Masses'], bins=losbins, alpha=histalpha, label=geom)
+        ax4.hist(data['Line-of-Sight Masses'][0], bins=losbins, alpha=histalpha, label=geom)
         
     if 'disk.mass' in pars.keys():
         ax5.hist(data['disk.mass'], bins=dscbins, alpha=histalpha, label=geom)


### PR DESCRIPTION
binsfunction tweaks which allow for selecting a single aperture size to look at in mass-related parameters, instead of a series of groups all corresponding to different aperture sizes. we each need to find out which aperture size to look at, though!