### PR TITLE
update to show_source_on_spitzer

### DIFF
--- a/table_loading.py
+++ b/table_loading.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pylab as pl
+import time
 
 from astropy.io import fits
 from astropy.table import Table
@@ -111,9 +113,12 @@ def find_ALMAIMF_matches(tbl):
     return tbl
 
 
-def show_source_on_spitzer(fieldid, coords,
+def show_source_on_spitzer(fieldid, coords, source=None,
                            basepath='/orange/adamginsburg/ALMA_IMF/2017.1.01355.L/RestructuredImagingResults',
                            mips=False):
+    
+    tbl = Table.read('/blue/adamginsburg/adamginsburg/ALMA_IMF/SPICY_ALMAIMF/SPICY_withAddOns.fits')
+    
     pfxs = prefixes[fieldid]
     fig = show_fov_on_spitzer(**{key: f'{basepath}/{val}' for key,val in pfxs.items()},
                               fieldid=fieldid, spitzerpath=f'{basepath}/spitzer_datapath',
@@ -126,11 +131,23 @@ def show_source_on_spitzer(fieldid, coords,
     matches = ww.footprint_contains(coords)
 
     cc = coords[matches]
+    tbl.add_index('ALMAIMF_FIELDID')
+    tbl = tbl.loc[fieldid]
+    tbl.remove_indices('ALMAIMF_FIELDID')
+    
+    if source == None:
+        x=0
+        y=len(cc)
+    else:
+        tbl.add_index('SPICY')
+        rownum = tbl.loc_indices[source]
+        x=rownum
+        y=rownum+1
 
     ax = fig.gca()
-    ax.plot(cc.fk5.ra.deg, cc.fk5.dec.deg, 'wo', mfc='none', mec='w', markersize=10, transform=ax.get_transform('fk5'), )
-
-
+    ax.plot(cc[x:y].fk5.ra.deg, cc[x:y].fk5.dec.deg, 'w*', mfc='none', mec='w', markersize=17, transform=ax.get_transform('fk5'), )
+    
+    return fig
 
 
 def get_filters():

--- a/table_loading.py
+++ b/table_loading.py
@@ -136,16 +136,16 @@ def show_source_on_spitzer(fieldid, coords, source=None,
     tbl.remove_indices('ALMAIMF_FIELDID')
     
     if source == None:
-        x=0
-        y=len(cc)
+        start=0
+        stop=len(cc)
     else:
         tbl.add_index('SPICY')
         rownum = tbl.loc_indices[source]
-        x=rownum
-        y=rownum+1
+        start=rownum
+        stop=rownum+1
 
     ax = fig.gca()
-    ax.plot(cc[x:y].fk5.ra.deg, cc[x:y].fk5.dec.deg, 'w*', mfc='none', mec='w', markersize=17, transform=ax.get_transform('fk5'), )
+    ax.plot(cc[start:stop].fk5.ra.deg, cc[start:stop].fk5.dec.deg, 'w*', mfc='none', mec='w', markersize=17, transform=ax.get_transform('fk5'), )
     
     return fig
 


### PR DESCRIPTION
Update to show_source_on_spitzer function that allows it to either show one source, or, if source variable isn't defined, it will show all the sources. Useful for automating the process of generating and saving location figures for each source in a given region.