### PR TITLE
alpha scaling feature

### DIFF
--- a/plot_fit.py
+++ b/plot_fit.py
@@ -138,7 +138,7 @@ def plot_fit(bestfits_source, geometries_selection, deltachi2limit, mass_ul, fie
     colors = {}
     
     # scale alpha based on number of models
-    if show_all_models and alpha_allmodels==None:
+    if show_all_models and alpha_allmodels is None:
         if modelcount <= 50:
             alpha_allmodels = 0.5
         if 50 < modelcount <= 100:


### PR DESCRIPTION
default alpha_allmodels value changed to None

if an alpha_allmodels value is set, it will display with that value regardless. if set to None, it will select a transparency for the models based on how many there are, on a scale that can be tweaked later if needed.